### PR TITLE
Fixed issue #18840: Update twig_translation_helper.php

### DIFF
--- a/application/helpers/twig_translation_helper.php
+++ b/application/helpers/twig_translation_helper.php
@@ -55,4 +55,12 @@ function dummy_twig_translation_helper()
     gT("Indicates where the 'Other' option should be placed"); // From application/views/survey/questions/answer/list_dropdown/config.xml
     gT("Answer code for 'After specific answer option'"); // From application/views/survey/questions/answer/list_dropdown/config.xml
     gT("The code of the answer option after which the 'Other:' option will be placed if the position is set to 'After specific answer option'"); // From application/views/survey/questions/answer/list_dropdown/config.xml
+    gT("Normal"); // From application/views/survey/questions/answer/list_dropdown/config.xml (2023/09/09)
+    gT("Random"); // From application/views/survey/questions/answer/list_dropdown/config.xml (2023/09/09)
+    gT("Alphabetical"); // From application/views/survey/questions/answer/list_dropdown/config.xml (2023/09/09)
+    gT("Position for 'Other:' option"); // From application/views/survey/questions/answer/list_dropdown/config.xml (2023/09/09)
+    gT("Answer options order"); // From application/views/survey/questions/answer/list_dropdown/config.xml (2023/09/09)
+    gT("After specific answer option"); // From application/views/survey/questions/answer/list_dropdown/config.xml (2023/09/09)
+    gT("Before No Answer"); // From application/views/survey/questions/answer/list_dropdown/config.xml (2023/09/09)
+    gT("Present answer options in normal, random or alphabetical order"); //  From application/views/survey/questions/answer/list_dropdown/config.xml (2023/09/09)
 }


### PR DESCRIPTION
8 untranslated sentences from application/views/survey/questions/answer/list_dropdown/config.xml file added in twig_translation_helper.php This should add those sentences in gettext catalogue.

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
